### PR TITLE
Add mappings for "Shift Encoder Hold" values

### DIFF
--- a/resources/controllers/midi-fighter-twister.json
+++ b/resources/controllers/midi-fighter-twister.json
@@ -1,8 +1,10 @@
 {
-  "version": "2.8.0-rc.3",
-  "name": "DJ TechTools Midi Fighter Twister",
+  "version": "2.8.2",
+  "id": "LRAXi6bB",
+  "sendFeedbackOnlyIfArmed": true,
   "defaultGroup": {},
-  "groups": [
+  "defaultControllerGroup": {},
+  "controllerGroups": [
     {
       "id": "1b0ae2b7-d905-456c-861d-fa3f2c886795",
       "name": "Side buttons"
@@ -12,7 +14,7 @@
       "name": "Push encoders"
     }
   ],
-  "mappings": [
+  "controllerMappings": [
     {
       "id": "0c029363-71c7-4115-b8e0-7245ac1b6d4b",
       "name": "Encoder 1/1",
@@ -29,6 +31,25 @@
         "category": "virtual",
         "fxAnchor": "id",
         "soloBehavior": 1
+      }
+    },
+    {
+      "id": "09982944-472f-4c46-a9d8-868bebd56ec2",
+      "name": "Shift+Encoder 1/1",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 0,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 16
       }
     },
     {
@@ -65,6 +86,25 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 1
+      }
+    },
+    {
+      "id": "be815634-e549-4c21-a19c-a1a0fb16a273",
+      "name": "Shift+Encoder 1/2",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 1,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 17
       }
     },
     {
@@ -105,6 +145,25 @@
       }
     },
     {
+      "id": "d3ddd535-7a0e-4e96-83fb-4e780ac8465b",
+      "name": "Shift+Encoder 1/3",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 2,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 18
+      }
+    },
+    {
       "id": "b82d7752-d229-448f-bd42-af61b459e481",
       "name": "Button 1/3",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -139,6 +198,26 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 3
+      }
+    },
+    {
+      "id": "0d00056c-29bc-406f-879d-ba46f552104d",
+      "name": "Shift+Encoder 1/4",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 3,
+        "character": 3,
+        "is14Bit": false
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 19
       }
     },
     {
@@ -179,6 +258,25 @@
       }
     },
     {
+      "id": "ccb1287a-cf38-46fa-8fba-21b499e0b365",
+      "name": "Shift+Encoder 2/1",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 4,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 20
+      }
+    },
+    {
       "id": "50f3d56d-0f63-4086-9592-b3ce913db381",
       "name": "Button 2/1",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -213,6 +311,25 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 5
+      }
+    },
+    {
+      "id": "685072cd-a7c5-46b2-8051-969e37a56b0b",
+      "name": "Shift+Encoder 2/2",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 5,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 21
       }
     },
     {
@@ -253,6 +370,25 @@
       }
     },
     {
+      "id": "f36aad49-6e6d-4fbe-bd63-14d5c3570e48",
+      "name": "Shift+Encoder 2/3",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 6,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 22
+      }
+    },
+    {
       "id": "cd973603-c9b7-4ab0-9817-205576531ef1",
       "name": "Button 2/3",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -287,6 +423,25 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 7
+      }
+    },
+    {
+      "id": "3521219b-9a63-4590-87c3-f6d0166f032e",
+      "name": "Shift+Encoder 2/4",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 7,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 23
       }
     },
     {
@@ -327,6 +482,25 @@
       }
     },
     {
+      "id": "d51a7e02-1189-4881-9dae-9c545b147122",
+      "name": "Shift+Encoder 3/1",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 8,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 24
+      }
+    },
+    {
       "id": "16013c48-2a49-4672-bf3a-95eae05ef3a7",
       "name": "Button 3/1",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -361,6 +535,25 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 9
+      }
+    },
+    {
+      "id": "cb0126e0-27be-4b84-96a4-d59f07aa8eea",
+      "name": "Shift+Encoder 3/2",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 9,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 25
       }
     },
     {
@@ -401,6 +594,25 @@
       }
     },
     {
+      "id": "42517135-e708-489e-b95f-85764bbf436b",
+      "name": "Shift+Encoder 3/3",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 10,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 26
+      }
+    },
+    {
       "id": "f7a9305d-94ab-4fc9-9b64-a909e559354b",
       "name": "Button 3/3",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -435,6 +647,25 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 11
+      }
+    },
+    {
+      "id": "e4577f74-6d10-4158-9254-53ff39228b59",
+      "name": "Shift+Encoder 3/4",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 11,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 27
       }
     },
     {
@@ -475,6 +706,25 @@
       }
     },
     {
+      "id": "34716767-3b5a-4eb1-a146-5a29b18fae52",
+      "name": "Shift+Encoder 4/1",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 12,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 28
+      }
+    },
+    {
       "id": "1c091580-986f-42fe-8942-759d81df18b2",
       "name": "Button 4/1",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -512,6 +762,25 @@
       }
     },
     {
+      "id": "1734788d-0349-49a1-86df-49515eddae01",
+      "name": "Shift+Encoder 4/2",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 13,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 29
+      }
+    },
+    {
       "id": "9145b8a7-021e-46e9-bc24-588b5b70e3cd",
       "name": "Button 4/2",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
@@ -531,10 +800,10 @@
     },
     {
       "id": "9406038e-3c44-432d-8ecc-3f41540ae0c8",
-      "name": "Encoder 4/3",
+      "name": "Shift+Encoder 4/3",
       "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
       "source": {
-        "channel": 0,
+        "channel": 4,
         "number": 14,
         "character": 3
       },
@@ -545,7 +814,7 @@
         "category": "virtual",
         "fxAnchor": "id",
         "soloBehavior": 1,
-        "controlElementIndex": 14
+        "controlElementIndex": 30
       }
     },
     {
@@ -583,6 +852,25 @@
         "fxAnchor": "id",
         "soloBehavior": 1,
         "controlElementIndex": 15
+      }
+    },
+    {
+      "id": "143b72b2-8f60-48a2-9488-6b57beda0176",
+      "name": "Shift+Encoder 4/4",
+      "groupId": "c37662ef-631e-4ccf-a62b-08baab2167f9",
+      "source": {
+        "channel": 4,
+        "number": 15,
+        "character": 3
+      },
+      "mode": {
+        "maxStepSize": 1.0
+      },
+      "target": {
+        "category": "virtual",
+        "fxAnchor": "id",
+        "soloBehavior": 1,
+        "controlElementIndex": 31
       }
     },
     {
@@ -682,448 +970,5 @@
       "feedbackIsEnabled": false
     }
   ],
-  "customData": {
-    "companion": {
-      "controls": [
-        {
-          "height": 50,
-          "id": "a3c27c02-c52d-471c-b706-27b62e2a5dbe",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "a3c27c02-c52d-471c-b706-27b62e2a5dbe",
-            "1c86e131-a1b9-4e4c-91d5-18ca2404cc88"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 400,
-          "y": 0
-        },
-        {
-          "height": 50,
-          "id": "828d465a-9bd3-4436-9134-488a6feb1fbf",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "828d465a-9bd3-4436-9134-488a6feb1fbf",
-            "50f3d56d-0f63-4086-9592-b3ce913db381"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 100,
-          "y": 100
-        },
-        {
-          "height": 50,
-          "id": "d2849ec7-c895-44ee-bffa-34eef50f977c",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "d2849ec7-c895-44ee-bffa-34eef50f977c",
-            "8018c259-6f76-4133-9047-6410781896ad"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 400,
-          "y": 100
-        },
-        {
-          "height": 50,
-          "id": "0c029363-71c7-4115-b8e0-7245ac1b6d4b",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "0c029363-71c7-4115-b8e0-7245ac1b6d4b",
-            "e5543ad8-9e81-4baf-a82d-2c281445e705"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 100,
-          "y": 0
-        },
-        {
-          "height": 50,
-          "id": "54a066e2-48e3-4653-9fbb-ef907db09d87",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "54a066e2-48e3-4653-9fbb-ef907db09d87",
-            "b82d7752-d229-448f-bd42-af61b459e481"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 300,
-          "y": 0
-        },
-        {
-          "height": 50,
-          "id": "27521ef0-5cf8-45e9-9c90-4d4906cf6304",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "27521ef0-5cf8-45e9-9c90-4d4906cf6304",
-            "dd1a81d3-d607-4329-9d91-a6b888b0faaf"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 200,
-          "y": 0
-        },
-        {
-          "height": 50,
-          "id": "7190e2a6-e07c-4922-9bb4-d6d2b072d801",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "7190e2a6-e07c-4922-9bb4-d6d2b072d801",
-            "039f799b-537f-4277-abc1-03c506827083"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 200,
-          "y": 100
-        },
-        {
-          "height": 50,
-          "id": "45bbbd5d-34f7-4ab8-b496-eeb9cf602a78",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "45bbbd5d-34f7-4ab8-b496-eeb9cf602a78",
-            "cd973603-c9b7-4ab0-9817-205576531ef1"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 300,
-          "y": 100
-        },
-        {
-          "height": 50,
-          "id": "640eb2a4-735d-4d91-ae5b-63671dfab5d7",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "640eb2a4-735d-4d91-ae5b-63671dfab5d7",
-            "2e187a1d-fad0-47e4-8b89-d96b94500032"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 200,
-          "y": 200
-        },
-        {
-          "height": 50,
-          "id": "c865c503-25fc-4b81-bbc8-0731105a2656",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "c865c503-25fc-4b81-bbc8-0731105a2656",
-            "f7a9305d-94ab-4fc9-9b64-a909e559354b"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 300,
-          "y": 200
-        },
-        {
-          "height": 50,
-          "id": "55aa23b0-b820-4ebe-9b12-9fe40842ef27",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "55aa23b0-b820-4ebe-9b12-9fe40842ef27",
-            "6772a9e3-288b-4f4b-a0ae-3bce83009d4d"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 400,
-          "y": 300
-        },
-        {
-          "height": 50,
-          "id": "3b5fc1e8-42db-4581-947e-5dfa3d3c0bf4",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "3b5fc1e8-42db-4581-947e-5dfa3d3c0bf4",
-            "1c091580-986f-42fe-8942-759d81df18b2"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 100,
-          "y": 300
-        },
-        {
-          "height": 50,
-          "id": "a38435c0-3ac4-4174-b1b1-781eff7988c4",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "a38435c0-3ac4-4174-b1b1-781eff7988c4",
-            "9145b8a7-021e-46e9-bc24-588b5b70e3cd"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 200,
-          "y": 300
-        },
-        {
-          "height": 50,
-          "id": "9406038e-3c44-432d-8ecc-3f41540ae0c8",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "9406038e-3c44-432d-8ecc-3f41540ae0c8",
-            "232d989a-e0d7-47f9-9587-668ac12584a3"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 300,
-          "y": 300
-        },
-        {
-          "height": 50,
-          "id": "25b83ec2-54da-4c0a-8415-880a30ef6a1f",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "25b83ec2-54da-4c0a-8415-880a30ef6a1f",
-            "16013c48-2a49-4672-bf3a-95eae05ef3a7"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 100,
-          "y": 200
-        },
-        {
-          "height": 50,
-          "id": "7a5f1680-f5ed-463b-979d-b30916e3bb3a",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "center",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "7a5f1680-f5ed-463b-979d-b30916e3bb3a",
-            "6b8ad131-bed9-4ba7-a604-435cf0436c91"
-          ],
-          "shape": "circle",
-          "width": 50,
-          "x": 400,
-          "y": 200
-        },
-        {
-          "height": 50,
-          "id": "ee9df590-61cb-4746-a313-77356e58b35e",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "belowBottom",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "ee9df590-61cb-4746-a313-77356e58b35e"
-          ],
-          "shape": "rectangle",
-          "width": 50,
-          "x": 500,
-          "y": 50
-        },
-        {
-          "height": 50,
-          "id": "27bf2152-e7f4-45e5-9b98-dcae8965b91f",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "belowBottom",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "27bf2152-e7f4-45e5-9b98-dcae8965b91f"
-          ],
-          "shape": "rectangle",
-          "width": 50,
-          "x": 0,
-          "y": 50
-        },
-        {
-          "height": 50,
-          "id": "a78b277e-cfbf-4b2b-9cc6-1a550aeb87fd",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "belowBottom",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "ab054880-1c43-4f4a-b418-c3ea4d31b510"
-          ],
-          "shape": "rectangle",
-          "width": 50,
-          "x": 0,
-          "y": 250
-        },
-        {
-          "height": 50,
-          "id": "e312d2a2-ecf1-4189-95af-4174c43a750c",
-          "labelOne": {
-            "angle": 0,
-            "position": "aboveTop",
-            "sizeConstrained": true
-          },
-          "labelTwo": {
-            "angle": 0,
-            "position": "belowBottom",
-            "sizeConstrained": true
-          },
-          "mappings": [
-            "a57a2787-3919-46fb-8fdd-17fb83f4baf1"
-          ],
-          "shape": "rectangle",
-          "width": 50,
-          "x": 500,
-          "y": 250
-        }
-      ],
-      "gridDivisionCount": 2,
-      "gridSize": 50
-    }
-  }
+  "activeControllerId": "dj-techtools-midi-fighter-twister"
 }


### PR DESCRIPTION
When the Midi Fighter Twister's Encoder Switch Action Type is set to "Shift Encoder Hold," pushing down and turning the encoder sends a secondary value, allowing one encoder to control two knobs independently. These messages are sent on Ch.5.

This patch provides sources for these "Shift Encoder Hold" values on ch5, and maps them to Virtual Multis 17-32.