### PR TITLE
Added checking for VU_MODE on Track Peak

### DIFF
--- a/main/src/domain/targets/track_peak_target.rs
+++ b/main/src/domain/targets/track_peak_target.rs
@@ -60,17 +60,16 @@ impl<'a> Target<'a> for TrackPeakTarget {
 impl TrackPeakTarget {
     fn peak(&self) -> Option<Volume> {
         let reaper = Reaper::get().medium_reaper();
-        
         let vu_mode = unsafe {
             reaper.get_media_track_info_value(self.track.raw(), TrackAttributeKey::VuMode) as i32
         };
-        let mut channel_count = 2;
-        if vu_mode == 2 || vu_mode == 8 {
-            channel_count = unsafe {
+        let channel_count = if matches!(vu_mode, 2 | 8) {
+            unsafe {
                 reaper.get_media_track_info_value(self.track.raw(), TrackAttributeKey::Nchan) as i32
-            };
-        }
-
+            }
+        } else {
+            2
+        };
         if channel_count <= 0 {
             return None;
         }

--- a/main/src/domain/targets/track_peak_target.rs
+++ b/main/src/domain/targets/track_peak_target.rs
@@ -60,9 +60,17 @@ impl<'a> Target<'a> for TrackPeakTarget {
 impl TrackPeakTarget {
     fn peak(&self) -> Option<Volume> {
         let reaper = Reaper::get().medium_reaper();
-        let channel_count = unsafe {
-            reaper.get_media_track_info_value(self.track.raw(), TrackAttributeKey::Nchan) as i32
+        
+        let vu_mode = unsafe {
+            reaper.get_media_track_info_value(self.track.raw(), TrackAttributeKey::VuMode) as i32
         };
+        let mut channel_count = 2;
+        if vu_mode == 2 || vu_mode == 8 {
+            channel_count = unsafe {
+                reaper.get_media_track_info_value(self.track.raw(), TrackAttributeKey::Nchan) as i32
+            };
+        }
+
         if channel_count <= 0 {
             return None;
         }


### PR DESCRIPTION
https://github.com/helgoboss/realearn/issues/560

This change requires the change to the TrackAttribute enum here:

https://github.com/helgoboss/reaper-rs/pull/55

Compiled and passed the tests. It's just an idea, works for me but I don't know what is the best practice for mutable variables so edit as you see fit please, and thank you! I'll keep studying Rust and Realearn for future requests.

Looks like all VU modes use channels 1-2, except for Multichannel and Combined RMS. In Reaper's UI the mode Stereo RMS displays different values for channels 1 and 2 but Track Peak only returns a single value so it acts like Combined Stereo RMS in practice which for me personally is fine. Then currently as of 6.53, all LUFS meters follow channels 1-2 only.



<details>
<summary> Gif demo: </summary>

![vu_meter3](https://user-images.githubusercontent.com/58243333/163029570-4d7579ef-5748-4627-8847-f8cd8ded4613.gif)

</details>

Edit: sorry for broken grammar